### PR TITLE
Remake of Analyser

### DIFF
--- a/analyser.php
+++ b/analyser.php
@@ -2,105 +2,89 @@
 define('BASEPATH', __DIR__ . DIRECTORY_SEPARATOR);
 require_once BASEPATH . 'config.php';
 require_once BASEPATH . 'init.php';
-
 main();
-
 function main() {
-  
-  register_shutdown_function('fatal_handler');
-  
-  echo "\n\t---------------------------------\n
+    register_shutdown_function('fatal_handler');
+    echo "\n\t---------------------------------\n
     \tXNOHAT DDoS FIREWALL\n
     \tVersion: " . VERSION . "\n
     \txnohat@gmail.com\n
     -----------------------------------\n
     ";
-  
-  $ipblocklist = array();
-  
-  //exec('iptables -F BLOCKEDIP'); //flush chain rules
-  //exec("iptables-save | grep -v -- '-j BLOCKEDIP' | iptables-restore"); // delete all rules related to chain
-  //exec('iptables -X BLOCKEDIP'); //delete chain
-  exec('iptables -N BLOCKEDIP'); //create chain
-  exec('iptables -A BLOCKEDIP -j LOG --log-level 4 --log-prefix \'blockedip\''); //LOG any packets go to this BLOCKEDIP chain
-  exec('iptables -A BLOCKEDIP -j DROP'); //DROP any packets go to this BLOCKEDIP chain
-  
-  while (true) {
-    
-    try {
-      
-      //copy(DB_FILE,'access_log_for_analysis.db');
-      
-      $db = new SQLite3(DB_FILE);
-      //$db = new SQLite3(':memory:');
-      $db->query('PRAGMA synchronous = OFF');
-      $db->query('PRAGMA journal_mode = MEMORY');
-      $db->query('PRAGMA busy_timeout = 300000');
-      
-      //$res_count_request = $db->query('SELECT remote_ip, count(remote_ip) AS request_num FROM accesslog GROUP BY remote_ip ORDER BY request_num DESC'); //load all request in database is VERY SLOW
-      $res_count_request = $db->query('SELECT remote_ip, count(remote_ip) AS request_num FROM accesslog WHERE request_time BETWEEN "' . @date("Y-m-d H:i:s", time() - TIME_WINDOW) . '" AND "' . @date("Y-m-d H:i:s", time()) . '" GROUP BY remote_ip ORDER BY request_num DESC');
-      while ($row = $res_count_request->fetchArray()) {
-        //print_r($row);
-        if ($row['request_num'] >= THRESHOLD AND !in_array($row['remote_ip'], $exclude_ips)) {
-          
-          exec('iptables -A INPUT -s ' . $row['remote_ip'] . ' -j BLOCKEDIP');
-          
-          echo 'BLOCKED IP: ' . $row['remote_ip'] . ' (REQ_NUM: ' . $row['request_num'] . '/' . TIME_WINDOW . " seconds)\n";
-          file_put_contents('blockedip.log', $row['remote_ip'] . '-' . $row['request_num'] . "\n", FILE_APPEND);
-          file_put_contents('manualblockip.sh', 'iptables -A INPUT -s ' . $row['remote_ip'] . ' -j BLOCKEDIP' . "\n", FILE_APPEND);
-          
-          $ipblocklist[] = $row['remote_ip'];
+    setupFirewall();
+    while (true) {
+        try {
+            $db = new SQLite3(DB_FILE);
+            $db->query('PRAGMA synchronous = OFF');
+            $db->query('PRAGMA journal_mode = MEMORY');
+            $db->query('PRAGMA busy_timeout = 300000');
+            $start = date("Y-m-d H:i:s", time() - TIME_WINDOW);
+            $end   = date("Y-m-d H:i:s", time());
+            $query = '
+                SELECT remote_ip, COUNT(remote_ip) AS request_num
+                FROM accesslog
+                WHERE request_time BETWEEN "' . $start . '" AND "' . $end . '"
+                GROUP BY remote_ip
+                ORDER BY request_num DESC
+            ';
+            $res_count_request = $db->query($query);
+            while ($row = $res_count_request->fetchArray(SQLITE3_ASSOC)) {
+                $ip = $row['remote_ip'];
+                $requestNum = (int)$row['request_num'];
+                if ($requestNum >= THRESHOLD && shouldBlockIp($ip)) {
+                    blockIp($ip);
+                    echo 'BLOCKED IP: ' . $ip . ' (REQ_NUM: ' . $requestNum . '/' . TIME_WINDOW . " seconds)\n";
+                    file_put_contents('blockedip.log', $ip . '-' . $requestNum . "\n", FILE_APPEND);
+                    file_put_contents('manualblockip.sh', 'ipset add XNOHAT_BLOCKED ' . escapeshellarg($ip) . " timeout 3600 -exist\n", FILE_APPEND);
+                }
+            }
+            $db->close();
+            echo 'SLEEP IN ' . SLEEP_TIME . " seconds\n";
+            sleep(SLEEP_TIME);
+        } catch (Exception $error) {
+            echo "ERROR: " . $error->getMessage() . "\n";
+            sleep(SLEEP_TIME);
         }
-      }
-      
-      removeDuplicateIptablesRules();
-      
-      $db->close();
-      
-      echo 'SLEEP IN ' . SLEEP_TIME . "seconds\n";
-      sleep(SLEEP_TIME);
-      
     }
-    catch (Exception $error) {
-      //do nothing
-    }
-    
-  }
-  
 }
-
-function removeDuplicateIptablesRules() {
-  exec('iptables-save', $arr_iptables_save_output);
-  foreach ($arr_iptables_save_output as $k => $v) {
-    if (($kt = array_search($v, $arr_iptables_save_output)) !== FALSE AND $k != $kt AND strpos($v, '-A') !== FALSE) {
-      unset($arr_iptables_save_output[$kt]);
-    }
-  }
-  
-  $removed_duplicate_iptables_rules = implode("\n", $arr_iptables_save_output);
-  file_put_contents('removed_duplicate_iptables_rules.txt', $removed_duplicate_iptables_rules);
-  exec('iptables -F'); // Clear all rules
-  exec('iptables-restore < removed_duplicate_iptables_rules.txt');
-  echo "Removed Duplicate Rules from IPTables\n";
+function setupFirewall() {
+    exec('ipset create XNOHAT_BLOCKED hash:ip timeout 3600 -exist');
+    exec('ipset create XNOHAT_WHITELIST hash:ip -exist');
+    exec('iptables -N XNOHAT 2>/dev/null');
+    exec('iptables -F XNOHAT');
+    exec('iptables -A XNOHAT -m set --match-set XNOHAT_WHITELIST src -j RETURN');
+    exec('iptables -A XNOHAT -m set --match-set XNOHAT_BLOCKED src -j LOG --log-prefix "xnohat-blocked " --log-level 4');
+    exec('iptables -A XNOHAT -m set --match-set XNOHAT_BLOCKED src -j DROP');
+    exec('iptables -A XNOHAT -j RETURN');
+    exec('iptables -C INPUT -j XNOHAT 2>/dev/null || iptables -I INPUT 1 -j XNOHAT');
 }
-
-//function for fatal error case
+function shouldBlockIp($ip) {
+    global $exclude_ips;
+    if (!filter_var($ip, FILTER_VALIDATE_IP)) {
+        return false;
+    }
+    if (in_array($ip, $exclude_ips)) {
+        return false;
+    }
+    $safeIp = escapeshellarg($ip);
+    exec("ipset test XNOHAT_WHITELIST $safeIp >/dev/null 2>&1", $out, $code);
+    if ($code === 0) {
+        return false;
+    }
+    return true;
+}
+function blockIp($ip) {
+    if (!filter_var($ip, FILTER_VALIDATE_IP)) {
+        return;
+    }
+    $safeIp = escapeshellarg($ip);
+    exec("ipset add XNOHAT_BLOCKED $safeIp timeout 3600 -exist");
+}
 function fatal_handler() {
-  $errfile = 'unknown file';
-  $errstr  = 'shutdown';
-  $errno   = E_CORE_ERROR;
-  $errline = 0;
-  
-  $error = error_get_last();
-  
-  if (!is_null($error)) {
-    $errno   = $error['type'];
-    $errfile = $error['file'];
-    $errline = $error['line'];
-    $errstr  = $error['message'];
-    
-    main();
-  }
+    $error = error_get_last();
+    if (!is_null($error)) {
+        echo "FATAL ERROR: {$error['message']} in {$error['file']} on line {$error['line']}\n";
+        exit(1);
+    }
 }
-
 ?>


### PR DESCRIPTION
Hello,

I noticed your "Analyser" script had some issues in scalability and accessibility for other infrastructures. The two main points I noticed was that you were essentially making a script that requires you not use iptables at all as a user. But there wasn't a 'rollover' for many iptables features, so people can't customize tcp flags, chains, protocols, ports, packet size, hex strings, etc. The primary blocker from someone using their own iptables while using this, is the repeated calling of iptables -F. This also can cause a vulnerability/issue that'll cause INPUT DROP to be the 0 priority rule and cause a reboot. This can effect some systems substantially, ie if it hit a bank Friday night and their auto startup failed. 

I fixed both of these issues by reworking it to act and flush 1 chain. In the process I sort of rewrote all your PHP. This also allows for multiple concurrent operations, for example this entire script could just be for ip ratelimits, but you have another one for ports, specific protocols, etc that could all be launched by a delegator script. 

Also, you should use caution if you're operating with this in active WAN production. The script as you wrote it (which, I left this part of the logic unchanged) is a little "ballistic", it doesn't account for attackers abusing the function of the script (dropping IPs sending excessive requests). Say for example, this rule set was applied to a VPN and a user was using some game server like Fortnite. Somehow, the attacker has gotten the VPN IP and he spoofs the Fornite game server IP to the VPN IP in a high pps flood. The VPN would then drop the Fortnite game server, so the attacker's goal, "Deny service to the Fortnite Game" has succeeded. 

I might make another PR where I try to address this with a more robust filtering criteria, but for now, you can make a large amount of progress in preventing this with just one rule: **iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT** but you'll need to add it into the chain of course, or sort out the logic of how it will effect user firewalls if not in the chain. This is the first step toward a stateful system. Without this rule your firewall system is entirely stateless, which makes preventing an attack attempting to exploit your own filtering difficult. 